### PR TITLE
Enable package validation to track public API compatibility

### DIFF
--- a/src/Pure.HashCodes.Abstractions/Pure.HashCodes.Abstractions.csproj
+++ b/src/Pure.HashCodes.Abstractions/Pure.HashCodes.Abstractions.csproj
@@ -4,6 +4,8 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <EnablePackageValidation>true</EnablePackageValidation>
+    <PackageValidationBaselineVersion>0.2.0</PackageValidationBaselineVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <IsAotCompatible>true</IsAotCompatible>


### PR DESCRIPTION
Closes #16

Add `EnablePackageValidation` and `PackageValidationBaselineVersion` to the project file so that breaking public API changes are detected during build/pack before publishing.